### PR TITLE
Audio Playback on iOS by Configuring AVAudioSession

### DIFF
--- a/mlxtest/mlxtest/MLXTestModel.swift
+++ b/mlxtest/mlxtest/MLXTestModel.swift
@@ -12,6 +12,17 @@ class MLXTestModel: ObservableObject {
     audioEngine = AVAudioEngine()
     playerNode = AVAudioPlayerNode()
     audioEngine.attach(playerNode)
+
+    #if os(iOS)
+      do {
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.playback, mode: .default)
+        try audioSession.setActive(true)
+      } catch {
+        logPrint("Failed to set up AVAudioSession: \(error.localizedDescription)")
+        // Handle the error appropriately
+      }
+    #endif
   }
 
   func say(_ text: String) {


### PR DESCRIPTION
Audio playback was functional on macOS but silent on my iPhone. The audio data appeared to be generated correctly, but no sound was output.

This PR configures and activates the `AVAudioSession` for iOS.