### PR TITLE
Update mlx-swift to 0.30.6 — fixes static audio on iPhone 16 Pro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.30.2"),
+    .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.30.6"),
     // .package(url: "https://github.com/mlalma/eSpeakNGSwift", from: "1.0.1"),
     .package(url: "https://github.com/mlalma/MisakiSwift", exact: "1.0.6"),
     .package(url: "https://github.com/mlalma/MLXUtilsLibrary.git", exact: "0.0.6")


### PR DESCRIPTION
## Summary

- Updates mlx-swift dependency from `exact: "0.30.2"` to `from: "0.30.6"`
- mlx-swift 0.30.2 produces static/corrupted audio on iPhone 16 Pro due to two NAX bugs fixed in 0.30.6
- Changes pin style from `exact` to `from` to allow downstream consumers to resolve compatible versions

## Problem

On iPhone 16 Pro (A18 chip), Kokoro TTS generates white noise / static instead of speech when using mlx-swift 0.30.0–0.30.3. Audio sample values range -11 to +11 instead of the expected -0.33 to +0.54.

## Root Cause

Two bugs in mlx-swift's upstream mlx library:

1. **Incorrect NAX hardware detection** ([ml-explore/mlx#3083](https://github.com/ml-explore/mlx/pull/3083)) — The A18 chip (generation 17) was incorrectly detected as having Neural Accelerator (NAX) support, which is only available on generation 18+ (iPhone 17 Pro). When NAX was wrongly enabled, computations produced silently wrong numerical results.

2. **NAX overflow in ConvTransposed1d** ([ml-explore/mlx#3092](https://github.com/ml-explore/mlx/pull/3092)) — On iOS, transposed convolutions produced incorrect output for large tensors (time dimension > ~8000), directly affecting Kokoro's vocoder.

Both fixes are included in [mlx-swift 0.30.6](https://github.com/ml-explore/mlx-swift/releases/tag/0.30.6).

## Testing

Verified with kokoro-ios 1.0.10 + mlx-swift 0.30.6 on iPhone 16 Pro — clear audio output with correct sample values.

## Related Issues

- [KokoroTestApp#7](https://github.com/mlalma/KokoroTestApp/issues/7)
- [mlx-swift#344](https://github.com/ml-explore/mlx-swift/issues/344)
- [kokoro-ios#28](https://github.com/mlalma/kokoro-ios/issues/28)