### PR TITLE
fix: enumerate resources individually so iOS Simulator codesign accepts the bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary")
       ],
       resources: [
-       .copy("../../Resources/")
+       .copy("../../Resources/config.json")
       ]
     ),
     .testTarget(


### PR DESCRIPTION
## Summary

In Xcode 26 + iOS Simulator, codesign rejects this package's resource bundle with `bundle format unrecognized, invalid, or unsuitable`. The cause is that `.copy("../../Resources/")` preserves the `Resources/` subdirectory inside the emitted bundle (so it's structured as `KokoroSwift.bundle/Resources/config.json`), and the simulator codesign step refuses to sign that layout.

Replacing the directory copy with a per-file `.copy()` places `config.json` at the bundle root, which codesign accepts. Lookups via `Bundle.module.url(forResource:withExtension:)` continue to work because they search the whole bundle.

## Test plan
- [x] `xcodebuild` clean build for iOS Simulator (Xcode 26.4) succeeds; previously failed at the `CodeSign KokoroSwift_KokoroSwift.bundle` step
- [x] Resulting bundle is flat: `Info.plist`, `_CodeSignature/`, `config.json` at root
- [x] `Bundle.module` lookups still work at runtime