### PR TITLE
fix: declare MLXFast as KokoroSwift target dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,11 @@ let package = Package(
         .product(name: "MLXNN", package: "mlx-swift"),
         .product(name: "MLXRandom", package: "mlx-swift"),
         .product(name: "MLXFFT", package: "mlx-swift"),
+        // BuildingBlocks/LayerNormInference.swift imports MLXFast (uses
+        // MLXFast.layerNorm). Without this declaration, Xcode device builds
+        // fail at module resolution; `swift build` on macOS may resolve via
+        // transitive caching but iOS is strict.
+        .product(name: "MLXFast", package: "mlx-swift"),
         // .product(name: "eSpeakNGLib", package: "eSpeakNGSwift"),
         .product(name: "MisakiSwift", package: "MisakiSwift"),
         .product(name: "MLXUtilsLibrary", package: "MLXUtilsLibrary")


### PR DESCRIPTION
\`BuildingBlocks/LayerNormInference.swift\` imports \`MLXFast\` and calls \`MLXFast.layerNorm(weight:bias:eps:)\`, but \`Package.swift\` never declares \`MLXFast\` as a target dependency.

\`swift build\` on macOS appears to resolve via transitive caching (1.0.11 builds clean for me), but Xcode iOS device builds fail at module resolution:

\`\`\`
error: No such module 'MLXFast'
 import MLXFast
        ^
\`\`\`

This affects every tagged release (1.0.10, 1.0.11) and \`main\`.

## Fix
Add one product reference to the KokoroSwift target dependencies:

\`\`\`swift
.product(name: "MLXFast", package: "mlx-swift"),
\`\`\`

\`MLXFast\` already lives in the \`mlx-swift\` package that's pulled in here — this just exposes it to imports.

## Test plan
- [x] \`swift build\` on macOS: clean (already worked)
- [x] Xcode iOS device build: previously failed with \`No such module 'MLXFast'\`, now resolves

Thanks for the great library — found this while integrating KokoroSwift into a vocab learning iOS app. Happy to add a regression test if you'd like.